### PR TITLE
fix: Let cargo build openssl-sys in the shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,10 @@
           hydra-cli = pkgs.mkShell {
             inputsFrom = builtins.attrValues self.packages.${system};
             buildInputs = [ pkgs.cargo pkgs.rust-analyzer pkgs.clippy ];
+            nativeBuildInputs = [
+              pkgs.openssl
+              pkgs.pkg-config
+            ];
           };
           default = hydra-cli;
         };


### PR DESCRIPTION
Fixes `cargo build` in the shell, which gave:

```
error: could not find system library 'openssl' required by the 'openssl-sys' crate
```